### PR TITLE
EXP-5909 adding line to create the splash screen to ios

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ var getPlatforms = function (projectName) {
       { name: 'Default-Portrait~ipad.png',     width: 768,  height: 1024 },
       { name: 'Default-Portrait@2x~ipad.png',  width: 1536, height: 2048 },
       { name: 'Default-Landscape~ipad.png',    width: 1024, height: 768  },
-      { name: 'Default-Landscape@2x~ipad.png', width: 2048, height: 1536 }
+      { name: 'Default-Landscape@2x~ipad.png', width: 2048, height: 1536 },
+      { name: "Default@2x~universal~anyany.png", width: 2732, height: 2732 }
     ]
   });
   platforms.push({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-splash",
-  "version": "0.8.0-beta.2",
+  "version": "1.0.0",
   "description": "Automatic splash screen cropping for Cordova",
   "main": "index.js",
   "preferGlobal": "true",


### PR DESCRIPTION
## Basic

| Type | Ticket | Feature Flag |
|-|-|-|
|Chore |[EXP-5909](https://eventmobi.atlassian.net/browse/EXP-5909) | `none` |


## Details

- Adding a splash screen universal format.

## Verification

It is so hard to test because we need to make a build using that [PR](https://github.com/EventMobi/multiapp/pull/1622) and open the Cordova-splash index file on node_modules and add the same line that I added in this PR and you will see that the problem with splash screen has been solved.

## Blocker
No

## Checklist

- [ ] Changes don't introduce any new ESLint errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant confluence documentation
- [ ] Changes don't generate no new warnings or errors in console
- [ ] I have added tests for all the changes I have added
- [ ] New and existing unit tests pass locally with my changes
- [ ] It doesn't have any dependency on other repositories
